### PR TITLE
Tweak Flamenwerfer's flame cone burn range

### DIFF
--- a/zscript/icarus/weapons/Flamenwerfer 77/flamenwerfer77.zs
+++ b/zscript/icarus/weapons/Flamenwerfer 77/flamenwerfer77.zs
@@ -520,7 +520,7 @@ class HDFireCone : HDActor
 
 				if (invoker.PrettyLights.GetBool()) A_SpawnItemEx("FireballLight");
 
-				let burnRange = HDCONST_ONEMETRE * 1.5;
+				let burnRange = HDCONST_ONEMETRE * clamp(max(scale.x, 0.65) * 1.5, 1.0, 3.5);
 
 				BlockThingsIterator it = BlockThingsIterator.Create(self, burnRange);
 				while (it.Next())


### PR DESCRIPTION
At worst, the cone should now be `0.65 * 1.5 = 0.975`, clamped to 1x the `HDCONST_ONEMETRE`, which is slightly smaller than the flat 1.5x range. At its furthest, the cone should now be `2.15 * 1.5 = 3.225` which is double the flat 1.5x range.

In testing, enemies right in front of the player get immolated if they were shot at directly, which makes sense.  A cluster of enemies towards the far end of the cone can all get hit, leaving this feeling much more like a crowd control weapon rather than a short-range beam weapon, much better for a flamethrower.