### PR TITLE
Display Empty Battery if charge falls below 0 as well as equaling 0

### DIFF
--- a/zscript/icarus/weapons/Fenris/fenris.zs
+++ b/zscript/icarus/weapons/Fenris/fenris.zs
@@ -117,7 +117,7 @@ class HDFenris : HDCellWeapon
 			sb.DrawString(sb.pSmallFont, Col..BatPercent.."%\c-", (-14, -12), sb.DI_TEXT_ALIGN_RIGHT | sb.DI_SCREEN_CENTER_BOTTOM, Font.CR_DARKGRAY);
 		}
 
-		else if (BatteryCharge == 0)
+		else if (BatteryCharge <= 0)
 		{
 			sb.DrawString(sb.mAmountFont, "00000", (-14, -10), sb.DI_TEXT_ALIGN_RIGHT | sb.DI_TRANSLATABLE | sb.DI_SCREEN_CENTER_BOTTOM, Font.CR_DARKGRAY);
 		}


### PR DESCRIPTION
If you fire the Fenris once then alt-fire it three times, it'll drain to -1% and just not show the empty cell indicator.  This should fix that.